### PR TITLE
Only select ipv4 values

### DIFF
--- a/lib/wemo/util.ex
+++ b/lib/wemo/util.ex
@@ -41,7 +41,14 @@ defmodule WeMo.Util do
       end
     end)
     |> elem(1)
-    |> Keyword.fetch(:addr)
-    |> elem(1)
+    |> Keyword.get_values(:addr)
+    |> Enum.find(fn addr ->
+      case addr do
+        nil -> false
+        {127, 0, 0, 1} -> false
+        {_, _, _, _, _, _, _, _} -> false
+        {_, _, _, _} -> true
+      end
+    end)
   end
 end


### PR DESCRIPTION
`WeMo.Utils.get_ipv4_address/0` was still returning ipv6 addresses depending on the order the interface returned it in.

This adds an additional filter to make sure it's only ipv4.

Not completely happy with the implementation, but this currently works.